### PR TITLE
Add emphasis on where commands should be run

### DIFF
--- a/setup/SETUP.md
+++ b/setup/SETUP.md
@@ -6,7 +6,7 @@ First you need to find your login-id:
   - Remember to include the domain in your user (e.g. foobar@cs.aau.dk)
  
 
-For linux-users, you can replace the `<aau-id>` in the following text, and append to your `~/.ssh/config`:
+For linux-users, you can replace the `<aau-id>` in the following text, and append to your local `~/.ssh/config`:
 
 ```
 host aaugw
@@ -33,7 +33,7 @@ You can also replace `deis-mcc-login2.srv.aau.dk` with its backup `deis-mcc-logi
 It is recomended that you copy your ssh-key to the cluster to avoid typing your password more than strictly needed.
 If you do not allready have ssh-keys generated, [convenient guides exist online](https://help.github.com/en/github/authenticating-to-github/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent).
 
-Linux users can conviniently copy the key using the following commands.
+Linux users can conviniently copy the key using the following commands on your local machine.
 ```
 ssh-add
 ssh-copy-id deismcc

--- a/setup/SETUP.md
+++ b/setup/SETUP.md
@@ -33,7 +33,7 @@ You can also replace `deis-mcc-login2.srv.aau.dk` with its backup `deis-mcc-logi
 It is recomended that you copy your ssh-key to the cluster to avoid typing your password more than strictly needed.
 If you do not allready have ssh-keys generated, [convenient guides exist online](https://help.github.com/en/github/authenticating-to-github/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent).
 
-Linux users can conviniently copy the key using the following commands on your local machine.
+Linux users can conveniently copy the key to the DEIS-MCC machine using the following commands on your local machine.
 ```
 ssh-add
 ssh-copy-id deismcc


### PR DESCRIPTION
The instructions were a bit ambigious for people who aren't overly familiar with SSH